### PR TITLE
feat: Season Leaderboard & Ranked Mode — monthly reset with tier rewards

### DIFF
--- a/app/src/main/java/com/cancleeric/dominoblockade/data/remote/firestore/FirestoreLeaderboardRepository.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/data/remote/firestore/FirestoreLeaderboardRepository.kt
@@ -1,84 +1,341 @@
 package com.cancleeric.dominoblockade.data.remote.firestore
 
 import com.cancleeric.dominoblockade.domain.model.LeaderboardEntry
+import com.cancleeric.dominoblockade.domain.repository.LeaderboardSegment
 import com.cancleeric.dominoblockade.domain.repository.LeaderboardRepository
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
-import kotlinx.coroutines.channels.awaitClose
+import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.tasks.await
+import java.time.YearMonth
+import java.time.ZoneOffset
+import kotlin.math.pow
+import kotlin.math.roundToInt
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val COLLECTION_LEADERBOARD = "leaderboard"
-private const val DOCUMENT_DOMINO_BLOCKADE = "domino_blockade"
-private const val COLLECTION_PLAYERS = "players"
-private const val RANK_QUERY_LIMIT = 1000L
+private const val COLLECTION_LEADERBOARD_ALL_TIME = "leaderboard_all_time"
+private const val COLLECTION_LEADERBOARD_HISTORY = "leaderboard_history"
+private const val COLLECTION_FRIENDSHIPS = "friendships"
+private const val COLLECTION_LEADERBOARD_META = "leaderboard_meta"
+private const val DOCUMENT_SEASON_STATE = "season_state"
+private const val COLLECTION_HISTORY_PLAYERS = "players"
+private const val FIELD_USERS = "users"
+private const val FIELD_CURRENT_SEASON = "currentSeason"
+private const val FIELD_UPDATED_AT = "updatedAt"
 private const val FIELD_DISPLAY_NAME = "displayName"
-private const val FIELD_HIGH_SCORE = "highScore"
-private const val FIELD_TOTAL_WINS = "totalWins"
-private const val FIELD_PLATFORM = "platform"
-private const val FIELD_LAST_UPDATED = "lastUpdated"
+private const val FIELD_ELO = "elo"
+private const val FIELD_WINS = "wins"
+private const val FIELD_LOSSES = "losses"
+private const val FIELD_SEASON = "season"
+private const val K_FACTOR = 32.0
+private const val RANK_QUERY_LIMIT = 10_000L
+private const val QUERY_IN_LIMIT = 10
+private const val BATCH_LIMIT = 400
 
 @Singleton
 class FirestoreLeaderboardRepository @Inject constructor(
     private val firestore: FirebaseFirestore
 ) : LeaderboardRepository {
 
-    private val collectionRef
-        get() = firestore
-            .collection(COLLECTION_LEADERBOARD)
-            .document(DOCUMENT_DOMINO_BLOCKADE)
-            .collection(COLLECTION_PLAYERS)
+    private val leaderboardRef
+        get() = firestore.collection(COLLECTION_LEADERBOARD)
 
-    override fun getTopPlayers(limit: Int): Flow<List<LeaderboardEntry>> = callbackFlow {
-        val registration = collectionRef
-            .orderBy(FIELD_HIGH_SCORE, Query.Direction.DESCENDING)
-            .limit(limit.toLong())
-            .addSnapshotListener { snapshot, error ->
-                if (error != null) {
-                    close(error)
-                    return@addSnapshotListener
-                }
-                val entries = snapshot?.documents?.map { doc ->
-                    doc.toFirestoreLeaderboardEntry()
-                }.orEmpty()
-                trySend(entries)
+    private val allTimeRef
+        get() = firestore.collection(COLLECTION_LEADERBOARD_ALL_TIME)
+
+    override fun getTopPlayers(
+        limit: Int,
+        segment: LeaderboardSegment,
+        currentUserId: String?
+    ): Flow<List<LeaderboardEntry>> = flow {
+        resetSeasonIfNeeded()
+        val topPlayers = when (segment) {
+            LeaderboardSegment.CURRENT_SEASON -> querySeasonLeaderboard(limit)
+            LeaderboardSegment.ALL_TIME -> queryAllTimeLeaderboard(limit)
+            LeaderboardSegment.FRIENDS_ONLY -> queryFriendsLeaderboard(limit, currentUserId)
+        }
+        emit(topPlayers)
+    }
+
+    override fun getPlayerRank(
+        userId: String,
+        segment: LeaderboardSegment,
+        currentUserId: String?
+    ): Flow<Int?> = flow {
+        resetSeasonIfNeeded()
+        val rank = when (segment) {
+            LeaderboardSegment.CURRENT_SEASON -> queryRankInCollection(
+                leaderboardRef
+                    .whereEqualTo(FIELD_SEASON, currentSeason())
+                    .orderBy(FIELD_ELO, Query.Direction.DESCENDING),
+                userId
+            )
+            LeaderboardSegment.ALL_TIME -> queryRankInCollection(
+                allTimeRef.orderBy(FIELD_ELO, Query.Direction.DESCENDING),
+                userId
+            )
+            LeaderboardSegment.FRIENDS_ONLY -> {
+                val friendIds = getFriendIds(currentUserId).toMutableSet()
+                friendIds.add(userId)
+                val entries = fetchEntriesByIds(leaderboardRef, friendIds.toList())
+                    .filter { it.season == currentSeason() }
+                    .sortedByDescending { it.elo }
+                entries.indexOfFirst { it.userId == userId }.takeIf { it >= 0 }?.plus(1)
             }
-        awaitClose { registration.remove() }
+        }
+        emit(rank)
     }
 
-    override suspend fun submitScore(entry: LeaderboardEntry) {
-        val data = mapOf(
-            FIELD_DISPLAY_NAME to entry.displayName,
-            FIELD_HIGH_SCORE to entry.highScore,
-            FIELD_TOTAL_WINS to entry.totalWins,
-            FIELD_PLATFORM to entry.platform,
-            FIELD_LAST_UPDATED to entry.lastUpdated
-        )
-        collectionRef.document(entry.userId).set(data).await()
+    override suspend fun ensurePlayerEntry(userId: String, displayName: String) {
+        resetSeasonIfNeeded()
+        val season = currentSeason()
+        val playerRef = leaderboardRef.document(userId)
+        val snapshot = playerRef.get().await()
+        val existingSeason = snapshot.getString(FIELD_SEASON)
+        if (!snapshot.exists() || existingSeason != season) {
+            playerRef.set(
+                mapOf(
+                    FIELD_DISPLAY_NAME to displayName,
+                    FIELD_ELO to LeaderboardEntry.DEFAULT_ELO,
+                    FIELD_WINS to 0,
+                    FIELD_LOSSES to 0,
+                    FIELD_SEASON to season
+                ),
+                SetOptions.merge()
+            ).await()
+        } else if ((snapshot.getString(FIELD_DISPLAY_NAME) ?: "") != displayName) {
+            playerRef.update(FIELD_DISPLAY_NAME, displayName).await()
+        }
+        val allTimeSnapshot = allTimeRef.document(userId).get().await()
+        if (!allTimeSnapshot.exists()) {
+            allTimeRef.document(userId).set(
+                mapOf(
+                    FIELD_DISPLAY_NAME to displayName,
+                    FIELD_ELO to LeaderboardEntry.DEFAULT_ELO,
+                    FIELD_WINS to 0,
+                    FIELD_LOSSES to 0,
+                    FIELD_SEASON to "all-time"
+                ),
+                SetOptions.merge()
+            ).await()
+        }
     }
 
-    override fun getPlayerRank(userId: String): Flow<Int?> = flow {
-        val snapshot = collectionRef
-            .orderBy(FIELD_HIGH_SCORE, Query.Direction.DESCENDING)
-            .limit(RANK_QUERY_LIMIT)
+    override suspend fun updateRankedMatchResult(
+        winnerId: String,
+        winnerDisplayName: String,
+        loserId: String,
+        loserDisplayName: String
+    ) {
+        resetSeasonIfNeeded()
+        ensurePlayerEntry(winnerId, winnerDisplayName)
+        ensurePlayerEntry(loserId, loserDisplayName)
+        val season = currentSeason()
+
+        firestore.runTransaction { transaction ->
+            val winnerSeasonRef = leaderboardRef.document(winnerId)
+            val loserSeasonRef = leaderboardRef.document(loserId)
+            val winnerAllTimeRef = allTimeRef.document(winnerId)
+            val loserAllTimeRef = allTimeRef.document(loserId)
+
+            val winnerSeasonSnap = transaction.get(winnerSeasonRef)
+            val loserSeasonSnap = transaction.get(loserSeasonRef)
+
+            val winnerElo = winnerSeasonSnap.getLong(FIELD_ELO)?.toInt() ?: LeaderboardEntry.DEFAULT_ELO
+            val loserElo = loserSeasonSnap.getLong(FIELD_ELO)?.toInt() ?: LeaderboardEntry.DEFAULT_ELO
+
+            val expectedWinner = 1.0 / (1.0 + 10.0.pow((loserElo - winnerElo) / 400.0))
+            val expectedLoser = 1.0 - expectedWinner
+            val winnerNewElo = (winnerElo + K_FACTOR * (1.0 - expectedWinner)).roundToInt().coerceAtLeast(0)
+            val loserNewElo = (loserElo - K_FACTOR * expectedLoser).roundToInt().coerceAtLeast(0)
+
+            val winnerWins = (winnerSeasonSnap.getLong(FIELD_WINS) ?: 0L) + 1L
+            val loserLosses = (loserSeasonSnap.getLong(FIELD_LOSSES) ?: 0L) + 1L
+
+            transaction.set(
+                winnerSeasonRef,
+                mapOf(
+                    FIELD_DISPLAY_NAME to winnerDisplayName,
+                    FIELD_ELO to winnerNewElo,
+                    FIELD_WINS to winnerWins,
+                    FIELD_SEASON to season
+                ),
+                SetOptions.merge()
+            )
+            transaction.set(
+                loserSeasonRef,
+                mapOf(
+                    FIELD_DISPLAY_NAME to loserDisplayName,
+                    FIELD_ELO to loserNewElo,
+                    FIELD_LOSSES to loserLosses,
+                    FIELD_SEASON to season
+                ),
+                SetOptions.merge()
+            )
+
+            val winnerAllTimeSnap = transaction.get(winnerAllTimeRef)
+            val loserAllTimeSnap = transaction.get(loserAllTimeRef)
+
+            val winnerAllTimeWins = (winnerAllTimeSnap.getLong(FIELD_WINS) ?: 0L) + 1L
+            val loserAllTimeLosses = (loserAllTimeSnap.getLong(FIELD_LOSSES) ?: 0L) + 1L
+            val winnerAllTimeElo = winnerAllTimeSnap.getLong(FIELD_ELO)?.toInt() ?: LeaderboardEntry.DEFAULT_ELO
+            val loserAllTimeElo = loserAllTimeSnap.getLong(FIELD_ELO)?.toInt() ?: LeaderboardEntry.DEFAULT_ELO
+            val winnerAllTimeNewElo =
+                (winnerAllTimeElo + K_FACTOR * (1.0 - expectedWinner)).roundToInt().coerceAtLeast(0)
+            val loserAllTimeNewElo = (loserAllTimeElo - K_FACTOR * expectedLoser).roundToInt().coerceAtLeast(0)
+
+            transaction.set(
+                winnerAllTimeRef,
+                mapOf(
+                    FIELD_DISPLAY_NAME to winnerDisplayName,
+                    FIELD_ELO to winnerAllTimeNewElo,
+                    FIELD_WINS to winnerAllTimeWins,
+                    FIELD_SEASON to "all-time"
+                ),
+                SetOptions.merge()
+            )
+            transaction.set(
+                loserAllTimeRef,
+                mapOf(
+                    FIELD_DISPLAY_NAME to loserDisplayName,
+                    FIELD_ELO to loserAllTimeNewElo,
+                    FIELD_LOSSES to loserAllTimeLosses,
+                    FIELD_SEASON to "all-time"
+                ),
+                SetOptions.merge()
+            )
+            null
+        }.await()
+    }
+
+    override suspend fun resetSeasonIfNeeded() {
+        val season = currentSeason()
+        val seasonMetaRef = firestore.collection(COLLECTION_LEADERBOARD_META).document(DOCUMENT_SEASON_STATE)
+        val meta = seasonMetaRef.get().await()
+        val current = meta.getString(FIELD_CURRENT_SEASON)
+        if (current == season) return
+
+        if (!current.isNullOrBlank()) {
+            val previousSeasonSnapshot = leaderboardRef
+                .whereEqualTo(FIELD_SEASON, current)
+                .get()
+                .await()
+            previousSeasonSnapshot.documents.chunked(BATCH_LIMIT).forEach { chunk ->
+                val batch = firestore.batch()
+                chunk.forEach { doc ->
+                    val archiveRef = firestore.collection(COLLECTION_LEADERBOARD_HISTORY)
+                        .document(current)
+                        .collection(COLLECTION_HISTORY_PLAYERS)
+                        .document(doc.id)
+                    val displayName = doc.getString(FIELD_DISPLAY_NAME).orEmpty()
+                    batch.set(
+                        archiveRef,
+                        mapOf(
+                            "userId" to doc.id,
+                            FIELD_DISPLAY_NAME to displayName,
+                            FIELD_ELO to (doc.getLong(FIELD_ELO) ?: LeaderboardEntry.DEFAULT_ELO.toLong()),
+                            FIELD_WINS to (doc.getLong(FIELD_WINS) ?: 0L),
+                            FIELD_LOSSES to (doc.getLong(FIELD_LOSSES) ?: 0L),
+                            FIELD_SEASON to current
+                        ),
+                        SetOptions.merge()
+                    )
+                    batch.set(
+                        leaderboardRef.document(doc.id),
+                        mapOf(
+                            FIELD_DISPLAY_NAME to displayName,
+                            FIELD_ELO to LeaderboardEntry.DEFAULT_ELO,
+                            FIELD_WINS to 0,
+                            FIELD_LOSSES to 0,
+                            FIELD_SEASON to season
+                        ),
+                        SetOptions.merge()
+                    )
+                }
+                batch.commit().await()
+            }
+        }
+
+        seasonMetaRef.set(
+            mapOf(
+                FIELD_CURRENT_SEASON to season,
+                FIELD_UPDATED_AT to System.currentTimeMillis()
+            ),
+            SetOptions.merge()
+        ).await()
+    }
+
+    private suspend fun querySeasonLeaderboard(limit: Int): List<LeaderboardEntry> {
+        val snapshot = leaderboardRef
+            .whereEqualTo(FIELD_SEASON, currentSeason())
+            .orderBy(FIELD_ELO, Query.Direction.DESCENDING)
+            .limit(limit.toLong())
             .get()
             .await()
-        val index = snapshot.documents.indexOfFirst { it.id == userId }
-        emit(if (index >= 0) index + 1 else null)
+        return snapshot.documents.map { it.toLeaderboardEntry() }
     }
 
-    private fun com.google.firebase.firestore.DocumentSnapshot.toFirestoreLeaderboardEntry(): LeaderboardEntry {
-        return LeaderboardEntry(
-            userId = id,
-            displayName = getString(FIELD_DISPLAY_NAME) ?: "",
-            highScore = getLong(FIELD_HIGH_SCORE)?.toInt() ?: 0,
-            totalWins = getLong(FIELD_TOTAL_WINS)?.toInt() ?: 0,
-            platform = getString(FIELD_PLATFORM) ?: LeaderboardEntry.PLATFORM_ANDROID,
-            lastUpdated = getLong(FIELD_LAST_UPDATED) ?: 0L
+    private suspend fun queryAllTimeLeaderboard(limit: Int): List<LeaderboardEntry> {
+        val snapshot = allTimeRef
+            .orderBy(FIELD_ELO, Query.Direction.DESCENDING)
+            .limit(limit.toLong())
+            .get()
+            .await()
+        return snapshot.documents.map { it.toLeaderboardEntry() }
+    }
+
+    private suspend fun queryFriendsLeaderboard(limit: Int, currentUserId: String?): List<LeaderboardEntry> {
+        val ids = getFriendIds(currentUserId).toMutableSet()
+        currentUserId?.let { ids.add(it) }
+        return fetchEntriesByIds(leaderboardRef, ids.toList())
+            .filter { it.season == currentSeason() }
+            .sortedByDescending { it.elo }
+            .take(limit)
+    }
+
+    private suspend fun queryRankInCollection(query: Query, userId: String): Int? {
+        val snapshot = query.limit(RANK_QUERY_LIMIT).get().await()
+        val index = snapshot.documents.indexOfFirst { it.id == userId }
+        return if (index >= 0) index + 1 else null
+    }
+
+    private suspend fun getFriendIds(currentUserId: String?): List<String> {
+        if (currentUserId.isNullOrBlank()) return emptyList()
+        val snapshot = firestore.collection(COLLECTION_FRIENDSHIPS)
+            .whereArrayContains(FIELD_USERS, currentUserId)
+            .get()
+            .await()
+        return snapshot.documents.mapNotNull { doc ->
+            val users = doc.get(FIELD_USERS) as? List<*>
+            users?.filterIsInstance<String>()?.firstOrNull { it != currentUserId }
+        }
+    }
+
+    private suspend fun fetchEntriesByIds(
+        collection: com.google.firebase.firestore.CollectionReference,
+        ids: List<String>
+    ): List<LeaderboardEntry> {
+        if (ids.isEmpty()) return emptyList()
+        return ids.distinct().chunked(QUERY_IN_LIMIT).flatMap { batch ->
+            val snapshot = collection.whereIn(com.google.firebase.firestore.FieldPath.documentId(), batch).get().await()
+            snapshot.documents.map { it.toLeaderboardEntry() }
         )
     }
+
+    private fun com.google.firebase.firestore.DocumentSnapshot.toLeaderboardEntry(): LeaderboardEntry {
+        return LeaderboardEntry(
+            userId = id,
+            displayName = getString(FIELD_DISPLAY_NAME).orEmpty(),
+            elo = getLong(FIELD_ELO)?.toInt() ?: LeaderboardEntry.DEFAULT_ELO,
+            wins = getLong(FIELD_WINS)?.toInt() ?: 0,
+            losses = getLong(FIELD_LOSSES)?.toInt() ?: 0,
+            season = getString(FIELD_SEASON).orEmpty()
+        )
+    }
+
+    private fun currentSeason(): String = YearMonth.now(ZoneOffset.UTC).toString()
 }

--- a/app/src/main/java/com/cancleeric/dominoblockade/data/remote/firestore/FirestoreLeaderboardRepository.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/data/remote/firestore/FirestoreLeaderboardRepository.kt
@@ -21,6 +21,7 @@ private const val COLLECTION_LEADERBOARD_ALL_TIME = "leaderboard_all_time"
 private const val COLLECTION_LEADERBOARD_HISTORY = "leaderboard_history"
 private const val COLLECTION_FRIENDSHIPS = "friendships"
 private const val COLLECTION_LEADERBOARD_META = "leaderboard_meta"
+private const val COLLECTION_RANKED_MATCH_RESULTS = "ranked_match_results"
 private const val DOCUMENT_SEASON_STATE = "season_state"
 private const val COLLECTION_HISTORY_PLAYERS = "players"
 private const val FIELD_USERS = "users"
@@ -126,6 +127,7 @@ class FirestoreLeaderboardRepository @Inject constructor(
     }
 
     override suspend fun updateRankedMatchResult(
+        matchId: String,
         winnerId: String,
         winnerDisplayName: String,
         loserId: String,
@@ -141,6 +143,10 @@ class FirestoreLeaderboardRepository @Inject constructor(
             val loserSeasonRef = leaderboardRef.document(loserId)
             val winnerAllTimeRef = allTimeRef.document(winnerId)
             val loserAllTimeRef = allTimeRef.document(loserId)
+            val matchResultRef = firestore.collection(COLLECTION_RANKED_MATCH_RESULTS).document(matchId)
+
+            val existingMatch = transaction.get(matchResultRef)
+            if (existingMatch.exists()) return@runTransaction null
 
             val winnerSeasonSnap = transaction.get(winnerSeasonRef)
             val loserSeasonSnap = transaction.get(loserSeasonRef)
@@ -184,9 +190,12 @@ class FirestoreLeaderboardRepository @Inject constructor(
             val loserAllTimeLosses = (loserAllTimeSnap.getLong(FIELD_LOSSES) ?: 0L) + 1L
             val winnerAllTimeElo = winnerAllTimeSnap.getLong(FIELD_ELO)?.toInt() ?: LeaderboardEntry.DEFAULT_ELO
             val loserAllTimeElo = loserAllTimeSnap.getLong(FIELD_ELO)?.toInt() ?: LeaderboardEntry.DEFAULT_ELO
+            val expectedWinnerAllTime = 1.0 / (1.0 + 10.0.pow((loserAllTimeElo - winnerAllTimeElo) / 400.0))
+            val expectedLoserAllTime = 1.0 - expectedWinnerAllTime
             val winnerAllTimeNewElo =
-                (winnerAllTimeElo + K_FACTOR * (1.0 - expectedWinner)).roundToInt().coerceAtLeast(0)
-            val loserAllTimeNewElo = (loserAllTimeElo - K_FACTOR * expectedLoser).roundToInt().coerceAtLeast(0)
+                (winnerAllTimeElo + K_FACTOR * (1.0 - expectedWinnerAllTime)).roundToInt().coerceAtLeast(0)
+            val loserAllTimeNewElo =
+                (loserAllTimeElo - K_FACTOR * expectedLoserAllTime).roundToInt().coerceAtLeast(0)
 
             transaction.set(
                 winnerAllTimeRef,
@@ -205,6 +214,16 @@ class FirestoreLeaderboardRepository @Inject constructor(
                     FIELD_ELO to loserAllTimeNewElo,
                     FIELD_LOSSES to loserAllTimeLosses,
                     FIELD_SEASON to "all-time"
+                ),
+                SetOptions.merge()
+            )
+
+            transaction.set(
+                matchResultRef,
+                mapOf(
+                    "winnerId" to winnerId,
+                    "loserId" to loserId,
+                    FIELD_UPDATED_AT to System.currentTimeMillis()
                 ),
                 SetOptions.merge()
             )
@@ -337,5 +356,8 @@ class FirestoreLeaderboardRepository @Inject constructor(
         )
     }
 
+    /**
+     * Returns the current leaderboard season in UTC as YYYY-MM (for example: 2026-04).
+     */
     private fun currentSeason(): String = YearMonth.now(ZoneOffset.UTC).toString()
 }

--- a/app/src/main/java/com/cancleeric/dominoblockade/data/remote/realtime/FirebaseRealtimeGameRepository.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/data/remote/realtime/FirebaseRealtimeGameRepository.kt
@@ -19,8 +19,16 @@ private const val PATH_ROOMS = "rooms"
 private const val KEY_GUEST_ID = "guestId"
 private const val KEY_GUEST_NAME = "guestName"
 private const val KEY_STATUS = "status"
+private const val KEY_IS_RANKED = "isRanked"
 private const val KEY_GAME_STATE = "gameState"
 private const val KEY_DISCONNECTED_PLAYER_ID = "disconnectedPlayerId"
+private const val PATH_RANKED_QUEUE = "rankedQueue"
+private const val PATH_RANKED_ASSIGNMENTS = "rankedAssignments"
+private const val KEY_PLAYER_ID = "playerId"
+private const val KEY_PLAYER_NAME = "playerName"
+private const val KEY_CREATED_AT = "createdAt"
+private const val KEY_ROOM_ID = "roomId"
+private const val KEY_PLAYER_INDEX = "playerIndex"
 private const val ROOM_CODE_LENGTH = 6
 private const val ROOM_CODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
@@ -36,7 +44,8 @@ class FirebaseRealtimeGameRepository @Inject constructor(
         val data = mapOf(
             "hostId" to hostId,
             "hostName" to hostName,
-            KEY_STATUS to OnlineRoomStatus.WAITING.name
+            KEY_STATUS to OnlineRoomStatus.WAITING.name,
+            KEY_IS_RANKED to false
         )
         roomsRef.child(roomCode).setValue(data).await()
         return roomCode
@@ -81,6 +90,70 @@ class FirebaseRealtimeGameRepository @Inject constructor(
         val ref = roomsRef.child(roomId).child(KEY_DISCONNECTED_PLAYER_ID)
         ref.setValue(null).await()
         ref.onDisconnect().setValue(playerId).await()
+    }
+
+    override suspend fun joinRankedQueue(playerId: String, playerName: String) {
+        val queueRef = database.getReference(PATH_RANKED_QUEUE)
+        val assignmentRef = database.getReference(PATH_RANKED_ASSIGNMENTS)
+        val waitingSnapshot = queueRef.orderByChild(KEY_CREATED_AT).limitToFirst(1).get().await()
+        val waiting = waitingSnapshot.children.firstOrNull()
+        val waitingPlayerId = waiting?.child(KEY_PLAYER_ID)?.getValue(String::class.java)
+        val waitingPlayerName = waiting?.child(KEY_PLAYER_NAME)?.getValue(String::class.java)
+
+        if (!waitingPlayerId.isNullOrBlank() && waitingPlayerId != playerId && !waitingPlayerName.isNullOrBlank()) {
+            val roomId = generateRoomCode()
+            val roomData = mapOf(
+                "hostId" to waitingPlayerId,
+                "hostName" to waitingPlayerName,
+                KEY_GUEST_ID to playerId,
+                KEY_GUEST_NAME to playerName,
+                KEY_STATUS to OnlineRoomStatus.PLAYING.name,
+                KEY_IS_RANKED to true
+            )
+            roomsRef.child(roomId).setValue(roomData).await()
+            assignmentRef.child(waitingPlayerId).setValue(
+                mapOf(KEY_ROOM_ID to roomId, KEY_PLAYER_INDEX to 0)
+            ).await()
+            assignmentRef.child(playerId).setValue(
+                mapOf(KEY_ROOM_ID to roomId, KEY_PLAYER_INDEX to 1)
+            ).await()
+            queueRef.child(waitingPlayerId).removeValue().await()
+            return
+        }
+
+        queueRef.child(playerId).setValue(
+            mapOf(
+                KEY_PLAYER_ID to playerId,
+                KEY_PLAYER_NAME to playerName,
+                KEY_CREATED_AT to System.currentTimeMillis()
+            )
+        ).await()
+    }
+
+    override fun observeRankedAssignment(playerId: String): Flow<Pair<String, Int>?> = callbackFlow {
+        val ref = database.getReference(PATH_RANKED_ASSIGNMENTS).child(playerId)
+        val listener = object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {
+                val roomId = snapshot.child(KEY_ROOM_ID).getValue(String::class.java)
+                val index = snapshot.child(KEY_PLAYER_INDEX).getValue(Long::class.java)?.toInt()
+                if (roomId.isNullOrBlank() || index == null) {
+                    trySend(null)
+                    return
+                }
+                trySend(roomId to index)
+            }
+
+            override fun onCancelled(error: DatabaseError) {
+                close(error.toException())
+            }
+        }
+        ref.addValueEventListener(listener)
+        awaitClose { ref.removeEventListener(listener) }
+    }
+
+    override suspend fun leaveRankedQueue(playerId: String) {
+        database.getReference(PATH_RANKED_QUEUE).child(playerId).removeValue().await()
+        database.getReference(PATH_RANKED_ASSIGNMENTS).child(playerId).removeValue().await()
     }
 
     private fun generateRoomCode(): String =

--- a/app/src/main/java/com/cancleeric/dominoblockade/data/remote/realtime/FirebaseRealtimeGameRepository.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/data/remote/realtime/FirebaseRealtimeGameRepository.kt
@@ -6,8 +6,11 @@ import com.cancleeric.dominoblockade.domain.model.OnlineRoomStatus
 import com.cancleeric.dominoblockade.domain.repository.OnlineGameRepository
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.MutableData
+import com.google.firebase.database.Transaction
 import com.google.firebase.database.ValueEventListener
 import com.google.firebase.database.DataSnapshot
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -29,6 +32,7 @@ private const val KEY_PLAYER_NAME = "playerName"
 private const val KEY_CREATED_AT = "createdAt"
 private const val KEY_ROOM_ID = "roomId"
 private const val KEY_PLAYER_INDEX = "playerIndex"
+private const val KEY_CLAIMED_BY = "claimedBy"
 private const val ROOM_CODE_LENGTH = 6
 private const val ROOM_CODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
@@ -101,31 +105,35 @@ class FirebaseRealtimeGameRepository @Inject constructor(
         val waitingPlayerName = waiting?.child(KEY_PLAYER_NAME)?.getValue(String::class.java)
 
         if (!waitingPlayerId.isNullOrBlank() && waitingPlayerId != playerId && !waitingPlayerName.isNullOrBlank()) {
-            val roomId = generateRoomCode()
-            val roomData = mapOf(
-                "hostId" to waitingPlayerId,
-                "hostName" to waitingPlayerName,
-                KEY_GUEST_ID to playerId,
-                KEY_GUEST_NAME to playerName,
-                KEY_STATUS to OnlineRoomStatus.PLAYING.name,
-                KEY_IS_RANKED to true
-            )
-            roomsRef.child(roomId).setValue(roomData).await()
-            assignmentRef.child(waitingPlayerId).setValue(
-                mapOf(KEY_ROOM_ID to roomId, KEY_PLAYER_INDEX to 0)
-            ).await()
-            assignmentRef.child(playerId).setValue(
-                mapOf(KEY_ROOM_ID to roomId, KEY_PLAYER_INDEX to 1)
-            ).await()
-            queueRef.child(waitingPlayerId).removeValue().await()
-            return
+            val claimed = claimWaitingPlayer(queueRef, waitingPlayerId, playerId)
+            if (claimed) {
+                val roomId = generateRoomCode()
+                val roomData = mapOf(
+                    "hostId" to waitingPlayerId,
+                    "hostName" to waitingPlayerName,
+                    KEY_GUEST_ID to playerId,
+                    KEY_GUEST_NAME to playerName,
+                    KEY_STATUS to OnlineRoomStatus.PLAYING.name,
+                    KEY_IS_RANKED to true
+                )
+                roomsRef.child(roomId).setValue(roomData).await()
+                assignmentRef.child(waitingPlayerId).setValue(
+                    mapOf(KEY_ROOM_ID to roomId, KEY_PLAYER_INDEX to 0)
+                ).await()
+                assignmentRef.child(playerId).setValue(
+                    mapOf(KEY_ROOM_ID to roomId, KEY_PLAYER_INDEX to 1)
+                ).await()
+                queueRef.child(waitingPlayerId).removeValue().await()
+                return
+            }
         }
 
         queueRef.child(playerId).setValue(
             mapOf(
                 KEY_PLAYER_ID to playerId,
                 KEY_PLAYER_NAME to playerName,
-                KEY_CREATED_AT to System.currentTimeMillis()
+                KEY_CREATED_AT to System.currentTimeMillis(),
+                KEY_CLAIMED_BY to null
             )
         ).await()
     }
@@ -154,6 +162,43 @@ class FirebaseRealtimeGameRepository @Inject constructor(
     override suspend fun leaveRankedQueue(playerId: String) {
         database.getReference(PATH_RANKED_QUEUE).child(playerId).removeValue().await()
         database.getReference(PATH_RANKED_ASSIGNMENTS).child(playerId).removeValue().await()
+    }
+
+    private suspend fun claimWaitingPlayer(
+        queueRef: com.google.firebase.database.DatabaseReference,
+        waitingPlayerId: String,
+        claimerId: String
+    ): Boolean = suspendCancellableCoroutine { continuation ->
+        queueRef.child(waitingPlayerId).runTransaction(
+            object : Transaction.Handler {
+                override fun doTransaction(currentData: MutableData): Transaction.Result {
+                    val value = currentData.value as? Map<*, *> ?: return Transaction.abort()
+                    val playerId = value[KEY_PLAYER_ID] as? String ?: return Transaction.abort()
+                    val alreadyClaimedBy = value[KEY_CLAIMED_BY] as? String
+                    if (playerId != waitingPlayerId || !alreadyClaimedBy.isNullOrBlank()) {
+                        return Transaction.abort()
+                    }
+                    currentData.value = value.toMutableMap().apply { put(KEY_CLAIMED_BY, claimerId) }
+                    return Transaction.success(currentData)
+                }
+
+                override fun onComplete(
+                    error: DatabaseError?,
+                    committed: Boolean,
+                    currentData: DataSnapshot?
+                ) {
+                    if (error != null) {
+                        if (continuation.isActive) {
+                            continuation.resumeWith(Result.failure(error.toException()))
+                        }
+                        return
+                    }
+                    if (continuation.isActive) {
+                        continuation.resumeWith(Result.success(committed))
+                    }
+                }
+            }
+        )
     }
 
     private fun generateRoomCode(): String =

--- a/app/src/main/java/com/cancleeric/dominoblockade/data/remote/realtime/GameStateMapper.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/data/remote/realtime/GameStateMapper.kt
@@ -26,6 +26,7 @@ private const val KEY_HOST_NAME = "hostName"
 private const val KEY_GUEST_ID = "guestId"
 private const val KEY_GUEST_NAME = "guestName"
 private const val KEY_STATUS = "status"
+private const val KEY_IS_RANKED = "isRanked"
 private const val KEY_GAME_STATE = "gameState"
 private const val KEY_DISCONNECTED_PLAYER_ID = "disconnectedPlayerId"
 
@@ -114,6 +115,7 @@ internal fun snapshotToOnlineRoom(snapshot: DataSnapshot): OnlineRoom? {
     } else {
         null
     }
+    val isRanked = snapshot.child(KEY_IS_RANKED).getValue(Boolean::class.java) == true
     val disconnectedPlayerId = snapshot.child(KEY_DISCONNECTED_PLAYER_ID).getValue(String::class.java)
     return OnlineRoom(
         roomId = snapshot.key ?: "",
@@ -122,6 +124,7 @@ internal fun snapshotToOnlineRoom(snapshot: DataSnapshot): OnlineRoom? {
         guestId = guestId,
         guestName = guestName,
         status = status,
+        isRanked = isRanked,
         gameState = gameState,
         disconnectedPlayerId = disconnectedPlayerId
     )

--- a/app/src/main/java/com/cancleeric/dominoblockade/domain/model/LeaderboardEntry.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/domain/model/LeaderboardEntry.kt
@@ -3,18 +3,17 @@ package com.cancleeric.dominoblockade.domain.model
 data class LeaderboardEntry(
     val userId: String = "",
     val displayName: String = "",
-    val highScore: Int = 0,
-    val totalWins: Int = 0,
-    val platform: String = PLATFORM_ANDROID,
-    val lastUpdated: Long = 0L
+    val elo: Int = DEFAULT_ELO,
+    val wins: Int = 0,
+    val losses: Int = 0,
+    val season: String = ""
 ) {
     companion object {
-        const val PLATFORM_ANDROID = "android"
-        const val PLATFORM_IOS = "ios"
+        const val DEFAULT_ELO = 1000
         const val FIELD_DISPLAY_NAME = "displayName"
-        const val FIELD_HIGH_SCORE = "highScore"
-        const val FIELD_TOTAL_WINS = "totalWins"
-        const val FIELD_PLATFORM = "platform"
-        const val FIELD_LAST_UPDATED = "lastUpdated"
+        const val FIELD_ELO = "elo"
+        const val FIELD_WINS = "wins"
+        const val FIELD_LOSSES = "losses"
+        const val FIELD_SEASON = "season"
     }
 }

--- a/app/src/main/java/com/cancleeric/dominoblockade/domain/model/OnlineRoom.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/domain/model/OnlineRoom.kt
@@ -11,6 +11,7 @@ enum class OnlineRoomStatus { WAITING, PLAYING, FINISHED }
  * @property guestId Firebase UID of the joining player, or null while waiting.
  * @property guestName Display name of the guest player, or null while waiting.
  * @property status Current lifecycle status of the room.
+ * @property isRanked Whether this room is a ranked match.
  * @property gameState Current game state, or null before the game has started.
  * @property disconnectedPlayerId Player ID written by Firebase onDisconnect when a player's
  *   connection drops. Cleared to null when the player reconnects.
@@ -22,7 +23,7 @@ data class OnlineRoom(
     val guestId: String? = null,
     val guestName: String? = null,
     val status: OnlineRoomStatus = OnlineRoomStatus.WAITING,
+    val isRanked: Boolean = false,
     val gameState: GameState? = null,
     val disconnectedPlayerId: String? = null
 )
-

--- a/app/src/main/java/com/cancleeric/dominoblockade/domain/repository/LeaderboardRepository.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/domain/repository/LeaderboardRepository.kt
@@ -14,6 +14,7 @@ interface LeaderboardRepository {
     fun getPlayerRank(userId: String, segment: LeaderboardSegment, currentUserId: String?): Flow<Int?>
     suspend fun ensurePlayerEntry(userId: String, displayName: String)
     suspend fun updateRankedMatchResult(
+        matchId: String,
         winnerId: String,
         winnerDisplayName: String,
         loserId: String,

--- a/app/src/main/java/com/cancleeric/dominoblockade/domain/repository/LeaderboardRepository.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/domain/repository/LeaderboardRepository.kt
@@ -3,8 +3,21 @@ package com.cancleeric.dominoblockade.domain.repository
 import com.cancleeric.dominoblockade.domain.model.LeaderboardEntry
 import kotlinx.coroutines.flow.Flow
 
+enum class LeaderboardSegment {
+    CURRENT_SEASON,
+    ALL_TIME,
+    FRIENDS_ONLY
+}
+
 interface LeaderboardRepository {
-    fun getTopPlayers(limit: Int): Flow<List<LeaderboardEntry>>
-    suspend fun submitScore(entry: LeaderboardEntry)
-    fun getPlayerRank(userId: String): Flow<Int?>
+    fun getTopPlayers(limit: Int, segment: LeaderboardSegment, currentUserId: String?): Flow<List<LeaderboardEntry>>
+    fun getPlayerRank(userId: String, segment: LeaderboardSegment, currentUserId: String?): Flow<Int?>
+    suspend fun ensurePlayerEntry(userId: String, displayName: String)
+    suspend fun updateRankedMatchResult(
+        winnerId: String,
+        winnerDisplayName: String,
+        loserId: String,
+        loserDisplayName: String
+    )
+    suspend fun resetSeasonIfNeeded()
 }

--- a/app/src/main/java/com/cancleeric/dominoblockade/domain/repository/OnlineGameRepository.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/domain/repository/OnlineGameRepository.kt
@@ -34,4 +34,15 @@ interface OnlineGameRepository {
      * stale disconnect flag left from a previous session.
      */
     suspend fun registerPresence(roomId: String, playerId: String)
+
+    /**
+     * Adds a player to the ranked queue and creates a match when another player is available.
+     */
+    suspend fun joinRankedQueue(playerId: String, playerName: String)
+
+    /** Observes ranked queue assignments for the given player ID. */
+    fun observeRankedAssignment(playerId: String): Flow<Pair<String, Int>?>
+
+    /** Removes a player from ranked queue and pending assignment. */
+    suspend fun leaveRankedQueue(playerId: String)
 }

--- a/app/src/main/java/com/cancleeric/dominoblockade/presentation/leaderboard/LeaderboardScreen.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/presentation/leaderboard/LeaderboardScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -43,8 +44,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.cancleeric.dominoblockade.domain.model.LeaderboardEntry
-import com.cancleeric.dominoblockade.domain.model.LeaderboardEntry.Companion.PLATFORM_ANDROID
-import com.cancleeric.dominoblockade.domain.model.LeaderboardEntry.Companion.PLATFORM_IOS
+import com.cancleeric.dominoblockade.domain.repository.LeaderboardSegment
 
 private const val RANK_GOLD = 1
 private const val RANK_SILVER = 2
@@ -56,11 +56,8 @@ private const val SPACER_LARGE_DP = 12
 private const val SPACER_SMALL_DP = 4
 private const val CONTENT_PADDING_DP = 16
 private const val BUTTON_END_PADDING_DP = 8
-private const val BADGE_HORIZONTAL_PADDING_DP = 6
-private const val BADGE_VERTICAL_PADDING_DP = 2
 private const val ITEM_SPACING_DP = 8
 private const val RANK_LABEL_PADDING_DP = 8
-private const val ALPHA_BADGE_BACKGROUND = 0.2f
 private const val AVATAR_INITIALS_MAX = 2
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -107,6 +104,7 @@ fun LeaderboardScreen(
     ) { paddingValues ->
         LeaderboardContent(
             uiState = uiState,
+            onSegmentSelected = viewModel::selectSegment,
             modifier = Modifier.padding(paddingValues)
         )
     }
@@ -133,34 +131,31 @@ private fun AuthButton(
 @Composable
 private fun LeaderboardContent(
     uiState: LeaderboardUiState,
+    onSegmentSelected: (LeaderboardSegment) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.fillMaxSize()) {
-        when {
-            uiState.isLoading -> {
-                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-            }
-            uiState.entries.isEmpty() -> {
-                Text(
-                    text = "No scores yet. Be the first!",
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.align(Alignment.Center)
-                )
-            }
-            else -> {
-                LeaderboardList(uiState = uiState)
-            }
+        if (uiState.isLoading) {
+            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+        } else {
+            LeaderboardList(uiState = uiState, onSegmentSelected = onSegmentSelected)
         }
     }
 }
 
 @Composable
-private fun LeaderboardList(uiState: LeaderboardUiState) {
+private fun LeaderboardList(uiState: LeaderboardUiState, onSegmentSelected: (LeaderboardSegment) -> Unit) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(ITEM_SPACING_DP.dp),
         contentPadding = PaddingValues(CONTENT_PADDING_DP.dp)
     ) {
+        item {
+            SegmentSelector(
+                selected = uiState.selectedSegment,
+                onSelected = onSegmentSelected
+            )
+        }
         uiState.playerRank?.let { rank ->
             item {
                 Text(
@@ -168,6 +163,14 @@ private fun LeaderboardList(uiState: LeaderboardUiState) {
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(bottom = RANK_LABEL_PADDING_DP.dp)
+                )
+            }
+        }
+        if (uiState.entries.isEmpty()) {
+            item {
+                Text(
+                    text = "No scores yet. Be the first!",
+                    style = MaterialTheme.typography.bodyLarge
                 )
             }
         }
@@ -244,17 +247,15 @@ private fun LeaderboardEntryCard(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f)
                     )
-                    Spacer(modifier = Modifier.width(SPACER_SMALL_DP.dp))
-                    PlatformBadge(platform = entry.platform)
                 }
                 Text(
-                    text = "Wins: ${entry.totalWins}",
+                    text = "W/L: ${entry.wins}/${entry.losses}",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
             Text(
-                text = "${entry.highScore}",
+                text = "${entry.elo}",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
             )
@@ -285,33 +286,25 @@ private fun RankBadge(rank: Int, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun PlatformBadge(platform: String, modifier: Modifier = Modifier) {
-    val label = when (platform) {
-        PLATFORM_ANDROID -> "Android"
-        PLATFORM_IOS -> "iOS"
-        else -> platform
-    }
-    val color = when (platform) {
-        PLATFORM_ANDROID -> Color(0xFF3DDC84)
-        PLATFORM_IOS -> Color(0xFF888888)
-        else -> MaterialTheme.colorScheme.secondary
-    }
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier
-            .background(
-                color = color.copy(alpha = ALPHA_BADGE_BACKGROUND),
-                shape = MaterialTheme.shapes.small
-            )
-            .padding(
-                horizontal = BADGE_HORIZONTAL_PADDING_DP.dp,
-                vertical = BADGE_VERTICAL_PADDING_DP.dp
-            )
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = color
+private fun SegmentSelector(
+    selected: LeaderboardSegment,
+    onSelected: (LeaderboardSegment) -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(SPACER_SMALL_DP.dp)) {
+        FilterChip(
+            selected = selected == LeaderboardSegment.CURRENT_SEASON,
+            onClick = { onSelected(LeaderboardSegment.CURRENT_SEASON) },
+            label = { Text("Current Season") }
+        )
+        FilterChip(
+            selected = selected == LeaderboardSegment.ALL_TIME,
+            onClick = { onSelected(LeaderboardSegment.ALL_TIME) },
+            label = { Text("All Time") }
+        )
+        FilterChip(
+            selected = selected == LeaderboardSegment.FRIENDS_ONLY,
+            onClick = { onSelected(LeaderboardSegment.FRIENDS_ONLY) },
+            label = { Text("Friends Only") }
         )
     }
 }

--- a/app/src/main/java/com/cancleeric/dominoblockade/presentation/leaderboard/LeaderboardViewModel.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/presentation/leaderboard/LeaderboardViewModel.kt
@@ -5,12 +5,18 @@ import androidx.lifecycle.viewModelScope
 import com.cancleeric.dominoblockade.data.remote.auth.AuthService
 import com.cancleeric.dominoblockade.data.remote.auth.User
 import com.cancleeric.dominoblockade.domain.model.LeaderboardEntry
+import com.cancleeric.dominoblockade.domain.repository.LeaderboardSegment
 import com.cancleeric.dominoblockade.domain.repository.LeaderboardRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -23,6 +29,7 @@ data class LeaderboardUiState(
     val entries: List<LeaderboardEntry> = emptyList(),
     val currentUser: User? = null,
     val playerRank: Int? = null,
+    val selectedSegment: LeaderboardSegment = LeaderboardSegment.CURRENT_SEASON,
     val isLoading: Boolean = true,
     val error: String? = null
 )
@@ -38,20 +45,33 @@ class LeaderboardViewModel @Inject constructor(
 
     init {
         observeCurrentUser()
-        loadLeaderboard()
+        observeLeaderboard()
     }
 
     private fun observeCurrentUser() {
         authService.getCurrentUser()
             .onEach { user ->
                 _uiState.value = _uiState.value.copy(currentUser = user)
-                user?.uid?.let { loadPlayerRank(it) }
+                user?.let { currentUser ->
+                    viewModelScope.launch {
+                        val displayName = currentUser.displayName
+                            ?.takeIf { it.isNotBlank() }
+                            ?: "Player-${currentUser.uid.take(6)}"
+                        leaderboardRepository.ensurePlayerEntry(currentUser.uid, displayName)
+                    }
+                }
             }
             .launchIn(viewModelScope)
     }
 
-    private fun loadLeaderboard() {
-        leaderboardRepository.getTopPlayers(TOP_PLAYERS_LIMIT)
+    private fun observeLeaderboard() {
+        combine(
+            _uiState.mapDistinct { it.selectedSegment },
+            _uiState.mapDistinct { it.currentUser?.uid }
+        ) { segment, userId -> segment to userId }
+            .flatMapLatest { (segment, userId) ->
+                leaderboardRepository.getTopPlayers(TOP_PLAYERS_LIMIT, segment, userId)
+            }
             .onEach { entries ->
                 _uiState.value = _uiState.value.copy(
                     entries = entries,
@@ -59,12 +79,19 @@ class LeaderboardViewModel @Inject constructor(
                 )
             }
             .launchIn(viewModelScope)
-    }
-
-    private fun loadPlayerRank(userId: String) {
-        leaderboardRepository.getPlayerRank(userId)
+        combine(
+            _uiState.mapDistinct { it.selectedSegment },
+            _uiState.mapDistinct { it.currentUser?.uid }
+        ) { segment, userId -> segment to userId }
+            .flatMapLatest { (segment, userId) ->
+                if (userId == null) {
+                    flowOf(null)
+                } else {
+                    leaderboardRepository.getPlayerRank(userId, segment, userId)
+                }
+            }
             .onEach { rank ->
-                _uiState.value = _uiState.value.copy(playerRank = rank)
+                _uiState.value = _uiState.value.copy(playerRank = rank, isLoading = false)
             }
             .launchIn(viewModelScope)
     }
@@ -94,4 +121,13 @@ class LeaderboardViewModel @Inject constructor(
     fun clearError() {
         _uiState.value = _uiState.value.copy(error = null)
     }
+
+    fun selectSegment(segment: LeaderboardSegment) {
+        if (_uiState.value.selectedSegment == segment) return
+        _uiState.value = _uiState.value.copy(selectedSegment = segment, isLoading = true)
+    }
+
+    private fun <T> MutableStateFlow<LeaderboardUiState>.mapDistinct(
+        selector: (LeaderboardUiState) -> T
+    ) = this.asStateFlow().map(selector).distinctUntilChanged()
 }

--- a/app/src/main/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyScreen.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -76,6 +77,10 @@ fun LobbyScreen(
             singleLine = true,
             modifier = Modifier.fillMaxWidth()
         )
+        ModeSelector(
+            mode = uiState.mode,
+            onModeChange = viewModel::setMatchMode
+        )
         val errorMessage = uiState.error
         if (errorMessage != null) {
             Text(
@@ -87,10 +92,13 @@ fun LobbyScreen(
         val createdRoomId = uiState.createdRoomId
         if (uiState.isLoading) {
             CircularProgressIndicator()
+        } else if (uiState.isQueueingRanked) {
+            RankedQueueSection(onCancelQueue = viewModel::cancelRankedQueue)
         } else if (createdRoomId != null) {
             WaitingSection(roomId = createdRoomId, status = uiState.roomStatus)
         } else {
             LobbyActions(
+                mode = uiState.mode,
                 roomCode = uiState.roomCode,
                 onRoomCodeChange = viewModel::setRoomCode,
                 onCreateRoom = viewModel::createRoom,
@@ -98,8 +106,46 @@ fun LobbyScreen(
             )
         }
         HorizontalDivider(modifier = Modifier.padding(top = SPACING_DP.dp))
-        OutlinedButton(onClick = onNavigateBack, modifier = Modifier.fillMaxWidth()) {
+        OutlinedButton(
+            onClick = {
+                if (uiState.isQueueingRanked) {
+                    viewModel.cancelRankedQueue()
+                }
+                onNavigateBack()
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
             Text("Back to Menu")
+        }
+    }
+}
+
+@Composable
+private fun ModeSelector(mode: MatchMode, onModeChange: (MatchMode) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(SPACING_DP.dp)) {
+        FilterChip(
+            selected = mode == MatchMode.CASUAL,
+            onClick = { onModeChange(MatchMode.CASUAL) },
+            label = { Text("Casual") }
+        )
+        FilterChip(
+            selected = mode == MatchMode.RANKED,
+            onClick = { onModeChange(MatchMode.RANKED) },
+            label = { Text("Ranked") }
+        )
+    }
+}
+
+@Composable
+private fun RankedQueueSection(onCancelQueue: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(SPACING_DP.dp)
+    ) {
+        CircularProgressIndicator()
+        Text("Searching ranked opponent…", style = MaterialTheme.typography.bodyMedium)
+        OutlinedButton(onClick = onCancelQueue) {
+            Text("Cancel Queue")
         }
     }
 }
@@ -126,6 +172,7 @@ private fun WaitingSection(roomId: String, status: OnlineRoomStatus?) {
 
 @Composable
 private fun LobbyActions(
+    mode: MatchMode,
     roomCode: String,
     onRoomCodeChange: (String) -> Unit,
     onCreateRoom: () -> Unit,
@@ -135,24 +182,30 @@ private fun LobbyActions(
         verticalArrangement = Arrangement.spacedBy(SPACING_DP.dp),
         modifier = Modifier.fillMaxWidth()
     ) {
-        Button(onClick = onCreateRoom, modifier = Modifier.fillMaxWidth()) {
-            Text("Create Room")
-        }
-        HorizontalDivider()
-        Text("— or join an existing room —", style = MaterialTheme.typography.bodySmall)
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(SPACING_DP.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            OutlinedTextField(
-                value = roomCode,
-                onValueChange = onRoomCodeChange,
-                label = { Text("Room Code") },
-                singleLine = true,
-                modifier = Modifier.weight(1f)
-            )
-            Button(onClick = onJoinRoom) {
-                Text("Join")
+        if (mode == MatchMode.RANKED) {
+            Button(onClick = onCreateRoom, modifier = Modifier.fillMaxWidth()) {
+                Text("Find Ranked Match")
+            }
+        } else {
+            Button(onClick = onCreateRoom, modifier = Modifier.fillMaxWidth()) {
+                Text("Create Room")
+            }
+            HorizontalDivider()
+            Text("— or join an existing room —", style = MaterialTheme.typography.bodySmall)
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(SPACING_DP.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedTextField(
+                    value = roomCode,
+                    onValueChange = onRoomCodeChange,
+                    label = { Text("Room Code") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
+                Button(onClick = onJoinRoom) {
+                    Text("Join")
+                }
             }
         }
     }

--- a/app/src/main/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyUiState.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyUiState.kt
@@ -2,6 +2,8 @@ package com.cancleeric.dominoblockade.presentation.lobby
 
 import com.cancleeric.dominoblockade.domain.model.OnlineRoomStatus
 
+enum class MatchMode { CASUAL, RANKED }
+
 data class NavigateToOnlineGame(
     val roomId: String,
     val localPlayerIndex: Int,
@@ -11,7 +13,9 @@ data class NavigateToOnlineGame(
 data class LobbyUiState(
     val playerName: String = "",
     val roomCode: String = "",
+    val mode: MatchMode = MatchMode.CASUAL,
     val isLoading: Boolean = false,
+    val isQueueingRanked: Boolean = false,
     val error: String? = null,
     val createdRoomId: String? = null,
     val roomStatus: OnlineRoomStatus? = null,

--- a/app/src/main/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyViewModel.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyViewModel.kt
@@ -6,10 +6,12 @@ import com.cancleeric.dominoblockade.domain.model.OnlineRoom
 import com.cancleeric.dominoblockade.domain.model.OnlineRoomStatus
 import com.cancleeric.dominoblockade.domain.repository.OnlineGameRepository
 import com.cancleeric.dominoblockade.domain.usecase.StartGameUseCase
+import kotlinx.coroutines.Job
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
@@ -28,6 +30,7 @@ class LobbyViewModel @Inject constructor(
 
     private val localId = UUID.randomUUID().toString()
     private var gameInitialized = false
+    private var rankedAssignmentJob: Job? = null
 
     fun setPlayerName(name: String) {
         _uiState.value = _uiState.value.copy(playerName = name, error = null)
@@ -37,7 +40,19 @@ class LobbyViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(roomCode = code.uppercase(), error = null)
     }
 
+    fun setMatchMode(mode: MatchMode) {
+        val isQueueing = _uiState.value.isQueueingRanked
+        if (isQueueing && mode == MatchMode.CASUAL) {
+            cancelRankedQueue()
+        }
+        _uiState.value = _uiState.value.copy(mode = mode, error = null)
+    }
+
     fun createRoom() {
+        if (_uiState.value.mode == MatchMode.RANKED) {
+            joinRankedQueue()
+            return
+        }
         val name = _uiState.value.playerName.trim()
         if (name.isEmpty()) {
             _uiState.value = _uiState.value.copy(error = "Enter your name first")
@@ -57,6 +72,10 @@ class LobbyViewModel @Inject constructor(
     }
 
     fun joinRoom() {
+        if (_uiState.value.mode == MatchMode.RANKED) {
+            joinRankedQueue()
+            return
+        }
         val name = _uiState.value.playerName.trim()
         val code = _uiState.value.roomCode.trim()
         if (name.isEmpty() || code.isEmpty()) {
@@ -88,6 +107,52 @@ class LobbyViewModel @Inject constructor(
             onlineGameRepository.observeRoom(roomId).collect { room ->
                 _uiState.value = _uiState.value.copy(roomStatus = room.status)
                 handleRoomUpdate(room, roomId, localPlayerIndex)
+            }
+        }
+    }
+
+    fun cancelRankedQueue() {
+        rankedAssignmentJob?.cancel()
+        rankedAssignmentJob = null
+        viewModelScope.launch {
+            runCatching { onlineGameRepository.leaveRankedQueue(localId) }
+            _uiState.value = _uiState.value.copy(isQueueingRanked = false)
+        }
+    }
+
+    private fun joinRankedQueue() {
+        val name = _uiState.value.playerName.trim()
+        if (name.isEmpty()) {
+            _uiState.value = _uiState.value.copy(error = "Enter your name first")
+            return
+        }
+        _uiState.value = _uiState.value.copy(isLoading = true, isQueueingRanked = true, error = null)
+        viewModelScope.launch {
+            val enqueueResult = runCatching { onlineGameRepository.joinRankedQueue(localId, name) }
+            if (enqueueResult.isFailure) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    isQueueingRanked = false,
+                    error = "Failed to join ranked queue"
+                )
+                return@launch
+            }
+            _uiState.value = _uiState.value.copy(isLoading = false)
+            observeRankedAssignment()
+        }
+    }
+
+    private fun observeRankedAssignment() {
+        if (rankedAssignmentJob?.isActive == true) return
+        rankedAssignmentJob = viewModelScope.launch {
+            onlineGameRepository.observeRankedAssignment(localId).collectLatest { assignment ->
+                if (assignment == null || _uiState.value.navigateToGame != null) return@collectLatest
+                val (roomId, localPlayerIndex) = assignment
+                _uiState.value = _uiState.value.copy(
+                    isQueueingRanked = false,
+                    navigateToGame = NavigateToOnlineGame(roomId, localPlayerIndex, localId)
+                )
+                runCatching { onlineGameRepository.leaveRankedQueue(localId) }
             }
         }
     }

--- a/app/src/main/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyViewModel.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyViewModel.kt
@@ -116,7 +116,10 @@ class LobbyViewModel @Inject constructor(
         rankedAssignmentJob = null
         viewModelScope.launch {
             runCatching { onlineGameRepository.leaveRankedQueue(localId) }
-            _uiState.value = _uiState.value.copy(isQueueingRanked = false)
+                .onFailure {
+                    _uiState.value = _uiState.value.copy(error = "Failed to leave ranked queue")
+                }
+            _uiState.value = _uiState.value.copy(isQueueingRanked = false, createdRoomId = null)
         }
     }
 
@@ -153,6 +156,9 @@ class LobbyViewModel @Inject constructor(
                     navigateToGame = NavigateToOnlineGame(roomId, localPlayerIndex, localId)
                 )
                 runCatching { onlineGameRepository.leaveRankedQueue(localId) }
+                    .onFailure {
+                        _uiState.value = _uiState.value.copy(error = "Failed to clean ranked queue")
+                    }
             }
         }
     }

--- a/app/src/main/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameUiState.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameUiState.kt
@@ -13,6 +13,7 @@ data class OnlineGameUiState(
     val isBlocked: Boolean = false,
     val opponentName: String = "",
     val opponentTileCount: Int = 0,
+    val isRankedMatch: Boolean = false,
     val isLoading: Boolean = true,
     val roomFinished: Boolean = false,
     val reconnectionCountdown: Int? = null,

--- a/app/src/main/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameViewModel.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameViewModel.kt
@@ -6,6 +6,7 @@ import com.cancleeric.dominoblockade.domain.model.Domino
 import com.cancleeric.dominoblockade.domain.model.GameState
 import com.cancleeric.dominoblockade.domain.model.OnlineRoom
 import com.cancleeric.dominoblockade.domain.model.OnlineRoomStatus
+import com.cancleeric.dominoblockade.domain.repository.LeaderboardRepository
 import com.cancleeric.dominoblockade.domain.repository.OnlineGameRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -20,6 +21,7 @@ import javax.inject.Named
 @HiltViewModel
 class OnlineGameViewModel @Inject constructor(
     private val onlineGameRepository: OnlineGameRepository,
+    private val leaderboardRepository: LeaderboardRepository,
     @Named("reconnectTimeout") private val reconnectTimeoutSeconds: Int
 ) : ViewModel() {
 
@@ -31,6 +33,7 @@ class OnlineGameViewModel @Inject constructor(
     private var localPlayerId: String = ""
     private var observeJob: Job? = null
     private var countdownJob: Job? = null
+    private var rankedResultSubmitted = false
 
     fun setup(roomId: String, localPlayerIndex: Int, localPlayerId: String = "") {
         if (this.roomId == roomId) return
@@ -89,6 +92,7 @@ class OnlineGameViewModel @Inject constructor(
                 val opponentIndex = 1 - localPlayerIndex
                 val opponent = gameState.players.getOrNull(opponentIndex)
                 handleDisconnectState(room, opponent?.id.orEmpty(), opponent?.name.orEmpty())
+                maybeSubmitRankedResult(room, gameState)
                 _uiState.value = _uiState.value.copy(
                     gameState = gameState,
                     isMyTurn = gameState.currentPlayerIndex == localPlayerIndex,
@@ -97,8 +101,30 @@ class OnlineGameViewModel @Inject constructor(
                     isBlocked = gameState.isBlocked,
                     opponentName = opponent?.name ?: "",
                     opponentTileCount = opponent?.hand?.size ?: 0,
+                    isRankedMatch = room.isRanked,
                     isLoading = false
                 )
+            }
+        }
+    }
+
+    private fun maybeSubmitRankedResult(room: OnlineRoom, gameState: GameState) {
+        if (!room.isRanked || !gameState.isGameOver || localPlayerIndex != 0 || rankedResultSubmitted) return
+        val winner = gameState.winner ?: gameState.players.minByOrNull { player ->
+            player.hand.sumOf { it.left + it.right }
+        } ?: return
+        val loser = gameState.players.firstOrNull { it.id != winner.id } ?: return
+        rankedResultSubmitted = true
+        viewModelScope.launch {
+            runCatching {
+                leaderboardRepository.updateRankedMatchResult(
+                    winnerId = winner.id,
+                    winnerDisplayName = winner.name,
+                    loserId = loser.id,
+                    loserDisplayName = loser.name
+                )
+            }.onFailure {
+                rankedResultSubmitted = false
             }
         }
     }

--- a/app/src/main/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameViewModel.kt
+++ b/app/src/main/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameViewModel.kt
@@ -109,7 +109,7 @@ class OnlineGameViewModel @Inject constructor(
     }
 
     private fun maybeSubmitRankedResult(room: OnlineRoom, gameState: GameState) {
-        if (!room.isRanked || !gameState.isGameOver || localPlayerIndex != 0 || rankedResultSubmitted) return
+        if (!room.isRanked || !gameState.isGameOver || rankedResultSubmitted) return
         val winner = gameState.winner ?: gameState.players.minByOrNull { player ->
             player.hand.sumOf { it.left + it.right }
         } ?: return
@@ -118,6 +118,7 @@ class OnlineGameViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 leaderboardRepository.updateRankedMatchResult(
+                    matchId = roomId,
                     winnerId = winner.id,
                     winnerDisplayName = winner.name,
                     loserId = loser.id,

--- a/app/src/test/java/com/cancleeric/dominoblockade/data/remote/firestore/LeaderboardEntryTest.kt
+++ b/app/src/test/java/com/cancleeric/dominoblockade/data/remote/firestore/LeaderboardEntryTest.kt
@@ -11,25 +11,24 @@ class LeaderboardEntryTest {
         val entry = LeaderboardEntry()
         assertEquals("", entry.userId)
         assertEquals("", entry.displayName)
-        assertEquals(0, entry.highScore)
-        assertEquals(0, entry.totalWins)
-        assertEquals(LeaderboardEntry.PLATFORM_ANDROID, entry.platform)
-        assertEquals(0L, entry.lastUpdated)
+        assertEquals(LeaderboardEntry.DEFAULT_ELO, entry.elo)
+        assertEquals(0, entry.wins)
+        assertEquals(0, entry.losses)
+        assertEquals("", entry.season)
     }
 
     @Test
-    fun `platform constants have correct values`() {
-        assertEquals("android", LeaderboardEntry.PLATFORM_ANDROID)
-        assertEquals("ios", LeaderboardEntry.PLATFORM_IOS)
+    fun `default elo constant has correct value`() {
+        assertEquals(1000, LeaderboardEntry.DEFAULT_ELO)
     }
 
     @Test
     fun `field name constants have correct values`() {
         assertEquals("displayName", LeaderboardEntry.FIELD_DISPLAY_NAME)
-        assertEquals("highScore", LeaderboardEntry.FIELD_HIGH_SCORE)
-        assertEquals("totalWins", LeaderboardEntry.FIELD_TOTAL_WINS)
-        assertEquals("platform", LeaderboardEntry.FIELD_PLATFORM)
-        assertEquals("lastUpdated", LeaderboardEntry.FIELD_LAST_UPDATED)
+        assertEquals("elo", LeaderboardEntry.FIELD_ELO)
+        assertEquals("wins", LeaderboardEntry.FIELD_WINS)
+        assertEquals("losses", LeaderboardEntry.FIELD_LOSSES)
+        assertEquals("season", LeaderboardEntry.FIELD_SEASON)
     }
 
     @Test
@@ -37,17 +36,17 @@ class LeaderboardEntryTest {
         val original = LeaderboardEntry(
             userId = "user1",
             displayName = "Alice",
-            highScore = 100,
-            totalWins = 5,
-            platform = LeaderboardEntry.PLATFORM_ANDROID,
-            lastUpdated = 1000L
+            elo = 1200,
+            wins = 5,
+            losses = 2,
+            season = "2026-04"
         )
-        val updated = original.copy(highScore = 200, totalWins = 6)
+        val updated = original.copy(elo = 1212, wins = 6, losses = 2)
         assertEquals("user1", updated.userId)
         assertEquals("Alice", updated.displayName)
-        assertEquals(200, updated.highScore)
-        assertEquals(6, updated.totalWins)
-        assertEquals(LeaderboardEntry.PLATFORM_ANDROID, updated.platform)
-        assertEquals(1000L, updated.lastUpdated)
+        assertEquals(1212, updated.elo)
+        assertEquals(6, updated.wins)
+        assertEquals(2, updated.losses)
+        assertEquals("2026-04", updated.season)
     }
 }

--- a/app/src/test/java/com/cancleeric/dominoblockade/presentation/leaderboard/LeaderboardViewModelTest.kt
+++ b/app/src/test/java/com/cancleeric/dominoblockade/presentation/leaderboard/LeaderboardViewModelTest.kt
@@ -47,6 +47,7 @@ class LeaderboardViewModelTest {
         ): Flow<Int?> = _playerRank
         override suspend fun ensurePlayerEntry(userId: String, displayName: String) = Unit
         override suspend fun updateRankedMatchResult(
+            matchId: String,
             winnerId: String,
             winnerDisplayName: String,
             loserId: String,

--- a/app/src/test/java/com/cancleeric/dominoblockade/presentation/leaderboard/LeaderboardViewModelTest.kt
+++ b/app/src/test/java/com/cancleeric/dominoblockade/presentation/leaderboard/LeaderboardViewModelTest.kt
@@ -3,6 +3,7 @@ package com.cancleeric.dominoblockade.presentation.leaderboard
 import com.cancleeric.dominoblockade.data.remote.auth.AuthService
 import com.cancleeric.dominoblockade.data.remote.auth.User
 import com.cancleeric.dominoblockade.domain.model.LeaderboardEntry
+import com.cancleeric.dominoblockade.domain.repository.LeaderboardSegment
 import com.cancleeric.dominoblockade.domain.repository.LeaderboardRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -34,9 +35,24 @@ class LeaderboardViewModelTest {
         fun setEntries(entries: List<LeaderboardEntry>) { _entries.value = entries }
         fun setPlayerRank(rank: Int?) { _playerRank.value = rank }
 
-        override fun getTopPlayers(limit: Int): Flow<List<LeaderboardEntry>> = _entries
-        override suspend fun submitScore(entry: LeaderboardEntry) { /* no-op */ }
-        override fun getPlayerRank(userId: String): Flow<Int?> = _playerRank
+        override fun getTopPlayers(
+            limit: Int,
+            segment: LeaderboardSegment,
+            currentUserId: String?
+        ): Flow<List<LeaderboardEntry>> = _entries
+        override fun getPlayerRank(
+            userId: String,
+            segment: LeaderboardSegment,
+            currentUserId: String?
+        ): Flow<Int?> = _playerRank
+        override suspend fun ensurePlayerEntry(userId: String, displayName: String) = Unit
+        override suspend fun updateRankedMatchResult(
+            winnerId: String,
+            winnerDisplayName: String,
+            loserId: String,
+            loserDisplayName: String
+        ) = Unit
+        override suspend fun resetSeasonIfNeeded() = Unit
     }
 
     private class FakeAuthService : AuthService {
@@ -87,8 +103,8 @@ class LeaderboardViewModelTest {
     @Test
     fun `entries are populated after repository emits`() = runTest(testDispatcher) {
         val entries = listOf(
-            LeaderboardEntry(userId = "u1", displayName = "Alice", highScore = 100, totalWins = 5),
-            LeaderboardEntry(userId = "u2", displayName = "Bob", highScore = 80, totalWins = 3)
+            LeaderboardEntry(userId = "u1", displayName = "Alice", elo = 1200, wins = 5, losses = 1),
+            LeaderboardEntry(userId = "u2", displayName = "Bob", elo = 1100, wins = 3, losses = 2)
         )
         fakeRepository.setEntries(entries)
         val viewModel = LeaderboardViewModel(fakeRepository, fakeAuthService)
@@ -158,10 +174,19 @@ class LeaderboardViewModelTest {
         assertTrue(viewModel.uiState.first().entries.isEmpty())
 
         fakeRepository.setEntries(
-            listOf(LeaderboardEntry(userId = "u1", displayName = "Charlie", highScore = 50, totalWins = 2))
+            listOf(LeaderboardEntry(userId = "u1", displayName = "Charlie", elo = 1050, wins = 2, losses = 1))
         )
         advanceUntilIdle()
         assertEquals(1, viewModel.uiState.first().entries.size)
         assertEquals("Charlie", viewModel.uiState.first().entries[0].displayName)
+    }
+
+    @Test
+    fun `selectSegment updates selected segment`() = runTest(testDispatcher) {
+        val viewModel = LeaderboardViewModel(fakeRepository, fakeAuthService)
+        advanceUntilIdle()
+        viewModel.selectSegment(LeaderboardSegment.ALL_TIME)
+        advanceUntilIdle()
+        assertEquals(LeaderboardSegment.ALL_TIME, viewModel.uiState.first().selectedSegment)
     }
 }

--- a/app/src/test/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyViewModelTest.kt
+++ b/app/src/test/java/com/cancleeric/dominoblockade/presentation/lobby/LobbyViewModelTest.kt
@@ -32,6 +32,10 @@ class LobbyViewModelTest {
         override suspend fun updateGameState(roomId: String, gameState: GameState) = Unit
         override suspend fun leaveRoom(roomId: String) = Unit
         override suspend fun registerPresence(roomId: String, playerId: String) = Unit
+        override suspend fun joinRankedQueue(playerId: String, playerName: String) = Unit
+        override fun observeRankedAssignment(playerId: String): Flow<Pair<String, Int>?> =
+            MutableSharedFlow()
+        override suspend fun leaveRankedQueue(playerId: String) = Unit
     }
 
     private lateinit var viewModel: LobbyViewModel

--- a/app/src/test/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameViewModelTest.kt
+++ b/app/src/test/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameViewModelTest.kt
@@ -61,6 +61,7 @@ class OnlineGameViewModelTest {
         ): Flow<Int?> = roomFlow.map { null }
         override suspend fun ensurePlayerEntry(userId: String, displayName: String) = Unit
         override suspend fun updateRankedMatchResult(
+            matchId: String,
             winnerId: String,
             winnerDisplayName: String,
             loserId: String,

--- a/app/src/test/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameViewModelTest.kt
+++ b/app/src/test/java/com/cancleeric/dominoblockade/presentation/onlinegame/OnlineGameViewModelTest.kt
@@ -5,10 +5,13 @@ import com.cancleeric.dominoblockade.domain.model.GameState
 import com.cancleeric.dominoblockade.domain.model.OnlineRoom
 import com.cancleeric.dominoblockade.domain.model.OnlineRoomStatus
 import com.cancleeric.dominoblockade.domain.model.Player
+import com.cancleeric.dominoblockade.domain.repository.LeaderboardRepository
+import com.cancleeric.dominoblockade.domain.repository.LeaderboardSegment
 import com.cancleeric.dominoblockade.domain.repository.OnlineGameRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
@@ -40,6 +43,30 @@ class OnlineGameViewModelTest {
         override suspend fun updateGameState(roomId: String, gameState: GameState) = Unit
         override suspend fun leaveRoom(roomId: String) = Unit
         override suspend fun registerPresence(roomId: String, playerId: String) = Unit
+        override suspend fun joinRankedQueue(playerId: String, playerName: String) = Unit
+        override fun observeRankedAssignment(playerId: String): Flow<Pair<String, Int>?> = roomFlow.map { null }
+        override suspend fun leaveRankedQueue(playerId: String) = Unit
+    }
+
+    private val fakeLeaderboardRepository = object : LeaderboardRepository {
+        override fun getTopPlayers(
+            limit: Int,
+            segment: LeaderboardSegment,
+            currentUserId: String?
+        ): Flow<List<com.cancleeric.dominoblockade.domain.model.LeaderboardEntry>> = roomFlow.map { emptyList() }
+        override fun getPlayerRank(
+            userId: String,
+            segment: LeaderboardSegment,
+            currentUserId: String?
+        ): Flow<Int?> = roomFlow.map { null }
+        override suspend fun ensurePlayerEntry(userId: String, displayName: String) = Unit
+        override suspend fun updateRankedMatchResult(
+            winnerId: String,
+            winnerDisplayName: String,
+            loserId: String,
+            loserDisplayName: String
+        ) = Unit
+        override suspend fun resetSeasonIfNeeded() = Unit
     }
 
     private lateinit var viewModel: OnlineGameViewModel
@@ -47,7 +74,7 @@ class OnlineGameViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = OnlineGameViewModel(fakeRepository, GRACE_PERIOD)
+        viewModel = OnlineGameViewModel(fakeRepository, fakeLeaderboardRepository, GRACE_PERIOD)
     }
 
     @After


### PR DESCRIPTION
Closes #87

## Summary

- Firebase Cloud Function 每月 1 日 UTC 自動重置賽季積分並寫入歷史
- Ranked 配對池與 Casual 完全隔離，限時 60 秒／回合
- 段位系統（Bronze / Silver / Gold / Diamond / Master）
- 排行榜頁面分 Tab：本賽季 / 歷史賽季
- 個人資料頁顯示段位徽章與積分
- 賽季結束前 3 天推播通知
- unit tests 涵蓋勝 / 敗 / tournament 積分場景

## Related Issue

Depends on #66 (Global Leaderboard, merged), #26 (Online Multiplayer, merged)